### PR TITLE
feat: flow stream info tab

### DIFF
--- a/examples/evm/src/components/Forms/FlowStreamInfo/fields.tsx
+++ b/examples/evm/src/components/Forms/FlowStreamInfo/fields.tsx
@@ -1,0 +1,41 @@
+import type { ChangeEvent } from "react";
+import { useCallback } from "react";
+import _ from "lodash";
+import { REGEX_INTEGER } from "../../../constants";
+import Input from "../../Input";
+import useFormStore from "./store";
+
+export function StreamId() {
+  const { streamId, update } = useFormStore((state) => ({
+    streamId: state.streamId,
+    update: state.api.update,
+  }));
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = (() => {
+        const input = e.target.value;
+        if (_.isNil(input) || _.toString(input).length === 0) {
+          return undefined;
+        }
+        return _.toString(input);
+      })();
+
+      if (!value || new RegExp(REGEX_INTEGER).test(value)) {
+        update({ streamId: value });
+      }
+    },
+    [update],
+  );
+
+  return (
+    <Input
+      label={"Stream ID"}
+      id={"streamId"}
+      value={streamId || ""}
+      onChange={onChange}
+      format={"text"}
+      placeholder={"Enter stream ID, e.g., 100 ..."}
+    />
+  );
+}

--- a/examples/evm/src/components/Forms/FlowStreamInfo/index.tsx
+++ b/examples/evm/src/components/Forms/FlowStreamInfo/index.tsx
@@ -1,0 +1,192 @@
+import { useCallback } from "react";
+import styled from "styled-components";
+import _ from "lodash";
+import { useAccount } from "wagmi";
+import { FlowCore } from "../../../models";
+import { StreamId } from "./fields";
+import useStoreForm, { prefill } from "./store";
+
+const Wrapper = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  padding: 16px;
+  gap: 16px;
+`;
+
+const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${(props) => props.theme.colors.dark300};
+  margin-top: 8px;
+`;
+
+const Button = styled.button``;
+
+const Error = styled.p`
+  color: ${(props) => props.theme.colors.red};
+  margin-top: 16px;
+`;
+
+const Logs = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 16px;
+
+  label {
+    font-weight: 700;
+  }
+
+  ul {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 12px;
+    margin: 0 !important;
+  }
+`;
+
+const Actions = styled.div`
+  gap: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  & > div {
+    height: 20px;
+    width: 1px;
+    background-color: ${(props) => props.theme.colors.dark300};
+    margin: 0px;
+  }
+`;
+
+function FlowStreamInfo() {
+  const { isConnected } = useAccount();
+  const { error, logs, update } = useStoreForm((state) => ({
+    error: state.error,
+    logs: state.logs,
+    update: state.api.update,
+  }));
+
+  const onGetState = useCallback(async () => {
+    if (isConnected) {
+      const state = useStoreForm.getState();
+      try {
+        if (state.streamId) {
+          state.api.update({ error: undefined });
+          await FlowCore.getState(state.streamId, state.api.log);
+        } else {
+          state.api.update({ error: "Stream ID is not set" });
+        }
+      } catch (error) {
+        state.api.update({ error: _.toString(error) });
+      }
+    }
+  }, [isConnected]);
+
+  const onGetTotalDebt = useCallback(async () => {
+    if (isConnected) {
+      const state = useStoreForm.getState();
+      try {
+        if (state.streamId) {
+          state.api.update({ error: undefined });
+          await FlowCore.totalDebt(state.streamId, state.api.log);
+        } else {
+          state.api.update({ error: "Stream ID is not set" });
+        }
+      } catch (error) {
+        state.api.update({ error: _.toString(error) });
+      }
+    }
+  }, [isConnected]);
+
+  const onGetWithdrawableAmount = useCallback(async () => {
+    if (isConnected) {
+      const state = useStoreForm.getState();
+      try {
+        if (state.streamId) {
+          state.api.update({ error: undefined });
+          await FlowCore.withdrawableAmount(state.streamId, state.api.log);
+        } else {
+          state.api.update({ error: "Stream ID is not set" });
+        }
+      } catch (error) {
+        state.api.update({ error: _.toString(error) });
+      }
+    }
+  }, [isConnected]);
+
+  const onGetCoveredDebt = useCallback(async () => {
+    if (isConnected) {
+      const state = useStoreForm.getState();
+      try {
+        if (state.streamId) {
+          state.api.update({ error: undefined });
+          await FlowCore.coveredDebt(state.streamId, state.api.log);
+        } else {
+          state.api.update({ error: "Stream ID is not set" });
+        }
+      } catch (error) {
+        state.api.update({ error: _.toString(error) });
+      }
+    }
+  }, [isConnected]);
+
+  const onGetUncoveredDebt = useCallback(async () => {
+    if (isConnected) {
+      const state = useStoreForm.getState();
+      try {
+        if (state.streamId) {
+          state.api.update({ error: undefined });
+          await FlowCore.uncoveredDebt(state.streamId, state.api.log);
+        } else {
+          state.api.update({ error: "Stream ID is not set" });
+        }
+      } catch (error) {
+        state.api.update({ error: _.toString(error) });
+      }
+    }
+  }, [isConnected]);
+
+  const onPrefill = useCallback(() => {
+    update(prefill);
+  }, [update]);
+
+  return (
+    <Wrapper>
+      <StreamId />
+      <Divider />
+      <Actions>
+        <Button onClick={onPrefill}>Prefill form</Button>
+        <Button onClick={onGetState}>Get stream state</Button>
+        <Button onClick={onGetWithdrawableAmount}>Get withdrawable amount</Button>
+        <Button onClick={onGetTotalDebt}>Get total debt</Button>
+        <Button onClick={onGetCoveredDebt}>Get covered debt</Button>
+        <Button onClick={onGetUncoveredDebt}>Get uncovered debt</Button>
+      </Actions>
+      {error && <Error>{error}</Error>}
+      {logs.length > 0 && (
+        <>
+          <Divider />
+          <Logs>
+            <label>Logs</label>
+            <ul>
+              {logs.map((log) => (
+                <li key={log}>{log}</li>
+              ))}
+            </ul>
+          </Logs>
+        </>
+      )}
+    </Wrapper>
+  );
+}
+
+export default FlowStreamInfo;

--- a/examples/evm/src/components/Forms/FlowStreamInfo/store.tsx
+++ b/examples/evm/src/components/Forms/FlowStreamInfo/store.tsx
@@ -1,0 +1,43 @@
+import { shallow } from "zustand/shallow";
+import { createWithEqualityFn } from "zustand/traditional";
+import type { IStoreFormFlowStreamInfo } from "../../../types";
+
+const initial: Omit<IStoreFormFlowStreamInfo, "api"> = {
+  error: undefined,
+  logs: [],
+  streamId: undefined,
+};
+
+const prefill: Omit<IStoreFormFlowStreamInfo, "api"> = {
+  error: undefined,
+  logs: [],
+  streamId: "100",
+};
+
+const useStoreForm = createWithEqualityFn<IStoreFormFlowStreamInfo>(
+  (set) => ({
+    ...initial,
+    api: {
+      log: (value: string) =>
+        set((prev) => {
+          return {
+            logs: [...prev.logs, value],
+          };
+        }),
+      update: (updates: Partial<IStoreFormFlowStreamInfo>) =>
+        set((_prev) => {
+          return {
+            ...updates,
+          };
+        }),
+      reset: () =>
+        set((_prev) => {
+          return initial;
+        }),
+    },
+  }),
+  shallow,
+);
+
+export { initial, prefill };
+export default useStoreForm;

--- a/examples/evm/src/components/Forms/index.tsx
+++ b/examples/evm/src/components/Forms/index.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import styled from "styled-components";
 import { useAccount } from "wagmi";
 import Flow from "./Flow";
+import FlowStreamInfo from "./FlowStreamInfo";
 import FlowWithdraw from "./FlowWithdraw";
 import LockupDynamic from "./LockupDynamic";
 import LockupHeadless from "./LockupHeadless";
@@ -143,9 +144,13 @@ function Forms() {
             <Tab data-active={tab === 1} onClick={() => setTab(1)}>
               <p>⬇️ Withdraw</p>
             </Tab>
+            <Tab data-active={tab === 2} onClick={() => setTab(2)}>
+              <p>📊 Stream Info</p>
+            </Tab>
           </Tabs>
           {tab === 0 && <Flow />}
           {tab === 1 && <FlowWithdraw />}
+          {tab === 2 && <FlowStreamInfo />}
         </>
       )}
     </Wrapper>

--- a/examples/evm/src/models/FlowCore.ts
+++ b/examples/evm/src/models/FlowCore.ts
@@ -1,9 +1,9 @@
 import BigNumber from "bignumber.js";
-import _ from "lodash";
+import { TransactionReceipt, decodeEventLog, formatUnits } from "viem";
 import { getAccount, readContract, readContracts, waitForTransactionReceipt, writeContract } from "wagmi/actions";
 import { config } from "../components/Web3";
 import { ABI, SEPOLIA_CHAIN_ID, contracts } from "../constants";
-import type { IAddress, ICreateAndDepositFlow, IWithdrawFlow } from "../types";
+import type { IAddress, ICreateAndDepositFlow, IStreamState, IWithdrawFlow } from "../types";
 import { erroneous, expect } from "../utils";
 
 class FlowCore {
@@ -70,12 +70,40 @@ class FlowCore {
 
       if (receipt?.status === "success") {
         log(`FL Stream successfully created.`);
+        const streamId = await this.extractStreamId(receipt);
+
+        if (streamId) {
+          log(`Stream ID: ${streamId}`);
+        }
       } else {
         log(`FL Stream creation failed.`);
       }
     } catch (error) {
       erroneous(error);
     }
+  }
+
+  static async extractStreamId(receipt: TransactionReceipt): Promise<bigint | undefined> {
+    for (const log of receipt.logs) {
+      try {
+        const decoded = decodeEventLog({
+          abi: ABI.SablierFlow.abi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (
+          decoded.eventName === "CreateFlowStream" &&
+          decoded.args &&
+          "streamId" in decoded.args &&
+          typeof decoded.args.streamId === "bigint"
+        ) {
+          return decoded.args.streamId;
+        }
+      } catch {
+        // ignore decoding errors for unrelated logs
+      }
+    }
+    return undefined;
   }
 
   static async doWithdraw(
@@ -149,6 +177,197 @@ class FlowCore {
       }
     } catch (error) {
       erroneous(error);
+    }
+  }
+
+  static async getState(streamId: string, log: (value: string) => void): Promise<IStreamState | undefined> {
+    try {
+      const streamIdBigInt = BigInt(streamId);
+
+      // Read stream data and owner in parallel using readContracts
+      const results = (await (readContracts as any)(config, {
+        contracts: [
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "getStream",
+            args: [streamIdBigInt],
+          },
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "ownerOf",
+            args: [streamIdBigInt],
+          },
+        ],
+        allowFailure: false,
+        authorizationList: undefined,
+      })) as unknown as [
+        {
+          balance: bigint;
+          ratePerSecond: bigint;
+          sender: IAddress;
+          snapshotTime: bigint;
+          isStream: boolean;
+          isTransferable: boolean;
+          isVoided: boolean;
+          token: IAddress;
+          tokenDecimals: number;
+          snapshotDebtScaled: bigint;
+        },
+        IAddress,
+        boolean,
+      ];
+
+      const [stream, owner] = results;
+
+      log(
+        `Stream: ${JSON.stringify(stream, (key, value) => (typeof value === "bigint" ? value.toString() : value), 2)}`,
+      );
+
+      return {
+        owner,
+        rps: stream.ratePerSecond,
+        startTimestamp: Number(stream.snapshotTime),
+        balance: stream.balance,
+        tokenAddress: stream.token,
+        tokenDecimals: stream.tokenDecimals,
+        snapshotTime: Number(stream.snapshotTime),
+        snapshotDebtScaled: stream.snapshotDebtScaled,
+        isTransferable: stream.isTransferable,
+        isVoided: stream.isVoided,
+      };
+    } catch (error) {
+      log(`Error getting stream state: ${error}`);
+      return undefined;
+    }
+  }
+
+  static async totalDebt(streamId: string, log: (value: string) => void): Promise<bigint | undefined> {
+    try {
+      const streamIdBigInt = BigInt(streamId);
+      const [totalDebt, decimals] = await readContracts(config, {
+        contracts: [
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "totalDebtOf",
+            args: [streamIdBigInt],
+          },
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "getTokenDecimals",
+            args: [streamIdBigInt],
+          },
+        ],
+      });
+      if (totalDebt.status === "success" && decimals.status === "success") {
+        log(`Total debt: ${formatUnits(totalDebt.result, decimals.result)}`);
+        return totalDebt.result;
+      } else {
+        log(`Error getting total debt: ${totalDebt.error || decimals.error}`);
+        return undefined;
+      }
+    } catch (error) {
+      log(`Error getting total debt: ${error}`);
+      return undefined;
+    }
+  }
+
+  static async withdrawableAmount(streamId: string, log: (value: string) => void): Promise<bigint | undefined> {
+    try {
+      const streamIdBigInt = BigInt(streamId);
+      const [withdrawableAmount, decimals] = await readContracts(config, {
+        contracts: [
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "withdrawableAmountOf",
+            args: [streamIdBigInt],
+          },
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "getTokenDecimals",
+            args: [streamIdBigInt],
+          },
+        ],
+      });
+      if (withdrawableAmount.status === "success" && decimals.status === "success") {
+        log(`Withdrawable amount: ${formatUnits(withdrawableAmount.result, decimals.result)}`);
+        return withdrawableAmount.result;
+      } else {
+        log(`Error getting withdrawable amount: ${withdrawableAmount.error || decimals.error}`);
+        return undefined;
+      }
+    } catch (error) {
+      log(`Error getting withdrawable amount: ${error}`);
+      return undefined;
+    }
+  }
+
+  static async coveredDebt(streamId: string, log: (value: string) => void): Promise<bigint | undefined> {
+    try {
+      const streamIdBigInt = BigInt(streamId);
+      const [coveredDebt, decimals] = await readContracts(config, {
+        contracts: [
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "coveredDebtOf",
+            args: [streamIdBigInt],
+          },
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "getTokenDecimals",
+            args: [streamIdBigInt],
+          },
+        ],
+      });
+      if (coveredDebt.status === "success" && decimals.status === "success") {
+        log(`Covered debt: ${formatUnits(coveredDebt.result, decimals.result)}`);
+        return coveredDebt.result;
+      } else {
+        log(`Error getting covered debt: ${coveredDebt.error || decimals.error}`);
+        return undefined;
+      }
+    } catch (error) {
+      log(`Error getting covered debt: ${error}`);
+      return undefined;
+    }
+  }
+
+  static async uncoveredDebt(streamId: string, log: (value: string) => void): Promise<bigint | undefined> {
+    try {
+      const streamIdBigInt = BigInt(streamId);
+      const [uncoveredDebt, decimals] = await readContracts(config, {
+        contracts: [
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "uncoveredDebtOf",
+            args: [streamIdBigInt],
+          },
+          {
+            address: contracts[SEPOLIA_CHAIN_ID].SablierFlow,
+            abi: ABI.SablierFlow.abi,
+            functionName: "getTokenDecimals",
+            args: [streamIdBigInt],
+          },
+        ],
+      });
+      if (uncoveredDebt.status === "success" && decimals.status === "success") {
+        log(`Uncovered debt: ${formatUnits(uncoveredDebt.result, decimals.result)}`);
+        return uncoveredDebt.result;
+      } else {
+        log(`Error getting uncovered debt: ${uncoveredDebt.error || decimals.error}`);
+        return undefined;
+      }
+    } catch (error) {
+      log(`Error getting uncovered debt: ${error}`);
+      return undefined;
     }
   }
 }

--- a/examples/evm/src/types/index.ts
+++ b/examples/evm/src/types/index.ts
@@ -114,6 +114,19 @@ export interface IStoreFormFlowWithdraw {
   };
 }
 
+export interface IStoreFormFlowStreamInfo {
+  logs: string[];
+  error: string | undefined;
+
+  streamId: string | undefined;
+
+  api: {
+    log: (value: string) => void;
+    update: (updates: Partial<IStoreFormFlowStreamInfo>) => void;
+    reset: () => void;
+  };
+}
+
 export type ICreateLinearWithDurations = {
   sender: IAddress;
   recipient: IAddress;
@@ -310,3 +323,16 @@ export type IBatchCreateTranchedWithTimestamps = [
     broker: { account: IAddress; fee: 0n };
   }[], // Array of streams
 ];
+
+export interface IStreamState {
+  owner: IAddress;
+  rps: bigint;
+  startTimestamp: number;
+  balance: bigint;
+  tokenAddress: IAddress;
+  tokenDecimals: number;
+  snapshotTime: number;
+  snapshotDebtScaled: bigint;
+  isTransferable: boolean;
+  isVoided: boolean;
+}


### PR DESCRIPTION
Hello!

I played with sandbox and evm examples for Flow Streams. And after create a Flow Stream, in sandbox we don't have any information about the stream. I created a new tab Stream Info for my own work and may be it's been useful for other. Also may create a bunch of other ABI functions and useful examples.

Also, I added a Stream ID into log after successfully created a stream

What do you think?